### PR TITLE
Add a variable to control when to Publish

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -40,23 +40,28 @@ mdl -s markdownlint-rules.rb .
 print_info "Mkdocs Build"
 mkdocs build
 
-if [ -n "${GITHUB_TOKEN}" ]; then
-    print_info "setup with GITHUB_TOKEN"
-    remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-elif [ -n "${PERSONAL_TOKEN}" ]; then
-    print_info "setup with PERSONAL_TOKEN"
-    remote_repo="https://x-access-token:${PERSONAL_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+if [ -n "${PUBLISH}" ]; then
+    print_info "Mkdocs GH-Deploy"
+    if [ -n "${GITHUB_TOKEN}" ]; then
+        print_info "setup with GITHUB_TOKEN"
+        remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    elif [ -n "${PERSONAL_TOKEN}" ]; then
+        print_info "setup with PERSONAL_TOKEN"
+        remote_repo="https://x-access-token:${PERSONAL_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    fi
+
+    if ! git config --get user.name; then
+        git config --global user.name "${GITHUB_ACTOR}"
+    fi
+
+    if ! git config --get user.email; then
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    fi
+
+    git remote rm origin
+    git remote add origin "${remote_repo}"
+
+    mkdocs gh-deploy -v --clean --remote-branch gh-pages --config-file "${CONFIG_FILE}" --force
 fi
 
-if ! git config --get user.name; then
-    git config --global user.name "${GITHUB_ACTOR}"
-fi
 
-if ! git config --get user.email; then
-    git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-fi
-
-git remote rm origin
-git remote add origin "${remote_repo}"
-
-mkdocs gh-deploy -v --clean --remote-branch gh-pages --config-file "${CONFIG_FILE}" --force


### PR DESCRIPTION
Small change to make it so that deploying occurs only when the PUBLISH variable is set. This allows this action to also be used for PRs when we only want to build and not deploy. [See oi-docs issue for details](https://github.com/OpenIndiana/oi-docs/issues/195).